### PR TITLE
Missing the svelte-hmr dependency

### DIFF
--- a/create-snowpack-app/app-template-svelte-typescript/package.json
+++ b/create-snowpack-app/app-template-svelte-typescript/package.json
@@ -36,6 +36,7 @@
     "@web/test-runner": "^0.13.3",
     "chai": "^4.3.4",
     "snowpack": "^3.8.8",
+    "svelte-hmr": "^0.14.7",
     "svelte-preprocess": "^4.7.2",
     "typescript": "^4.3.4"
   },


### PR DESCRIPTION
without this the pnpm cannot start the app. the pnpm is much more sensitive when it comes to the direct dependencies than others.

## Changes

Added dev  dep so pnpm can start the app

## Testing
check https://github.com/snowpackjs/snowpack/issues/3800

## Docs

closes https://github.com/snowpackjs/snowpack/issues/3800
